### PR TITLE
Added API for recently viewed products

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,11 +1,34 @@
 
 Spree::ProductsController.class_eval do
-    helper Spree::ReviewsHelper
-  
-    reviews_fields = [:avg_rating, :reviews_count]
-    reviews_fields.each { |attrib| Spree::PermittedAttributes.product_attributes << attrib }
-  
-    Spree::Api::ApiHelpers.class_eval do
-      reviews_fields.each { |attrib| class_variable_set(:@@product_attributes, class_variable_get(:@@product_attributes).push(attrib)) }
-    end
+  skip_before_action :set_current_order, only: :recently_viewed
+  after_action :save_recently_viewed, only: :recently_viewed
+
+  helper Spree::ReviewsHelper
+
+  reviews_fields = [:avg_rating, :reviews_count]
+  reviews_fields.each { |attrib| Spree::PermittedAttributes.product_attributes << attrib }
+
+  Spree::Api::ApiHelpers.class_eval do
+    reviews_fields.each { |attrib| class_variable_set(:@@product_attributes, class_variable_get(:@@product_attributes).push(attrib)) }
   end
+
+  def recently_viewed
+    products_Ids = cookies["recently_viewed_products"].split(",").map { |s| s.to_i }
+    products = Spree::Product.find_by_array_of_ids(products_Ids).includes(master: :images)
+    render json: {products: products}
+  end
+
+  private
+
+  def save_recently_viewed
+    id = params[:product_id]
+    return unless id.present?
+    rvp = (cookies["recently_viewed_products"] || "").split(", ")
+    rvp.delete(id)
+    rvp << id unless rvp.include?(id.to_s)
+    #Maximum 10 products can be displayed is recently viewded.
+    rvp_max_count = 10
+    rvp.delete_at(0) if rvp.size > rvp_max_count.to_i
+    cookies["recently_viewed_products"] = rvp.join(", ")
+  end
+end


### PR DESCRIPTION
## Why?

User Can should able to see his/her recently viewed products.

## This change addresses the need by:

This API will help to save recently viewed products by user as well as it will show the list for all product which user has viewed recently. It limits the products to 10.

[delivers #158123623]

[Pivotal Story](https://www.pivotaltracker.com/story/show/158123623)
