### PR TITLE
Added rabl for taxons icon(image)

### DIFF
--- a/app/views/spree/api/v1/taxons/taxons.v1.rabl
+++ b/app/views/spree/api/v1/taxons/taxons.v1.rabl
@@ -1,0 +1,5 @@
+attributes *taxon_attributes
+
+node :taxons do |t|
+  t.children.map { |c| partial('spree/api/v1/taxons/taxons', object: c).merge(icon: c.icon&.attachment(:normal)) }
+end


### PR DESCRIPTION
## Why?
**Feature**:  Display brands with there images.

## This change addresses the need by:
I will attach `Icon`(image) with taxons in json.
So we can get the brands images.

[delivers #158175411]

**[Story](https://www.pivotaltracker.com/story/show/158175411)**
