### PR TITLE
Payubiz payment gateway(hosted page) integration. (#40)

### DIFF
--- a/app/controllers/api/accounts_controller.rb
+++ b/app/controllers/api/accounts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::AccountsController < BaseController
-  before_action :check_authorization, except: %i[create]
+  before_action :check_authorization, except: %i[handle_payment canceled_payment]
 
   def serialization_scope
     current_order
@@ -44,6 +44,23 @@ class Api::AccountsController < BaseController
 
   def authenticated
     render_user
+  end
+
+  def handle_payment
+    order_id = params[:txnid]
+    @current_order = Spree::Order.find_by_number(order_id)
+    #Assuming that we do not having partial payments(one stroke payment only)
+    result = @current_order.payments.first.complete
+    if result
+      url = "#{ENV['FRONT_END_URL']}checkout/order-success?orderReferance=#{order_id}"
+      redirect_to url  
+    end
+  end
+
+  def canceled_payment
+    #WIP when user cancel payments
+    url = "#{ENV['FRONT_END_URL']}"
+      redirect_to url  
   end
 
   private

--- a/app/models/spree/payment_method/payubiz.rb
+++ b/app/models/spree/payment_method/payubiz.rb
@@ -1,0 +1,7 @@
+module Spree
+  class PaymentMethod::Payubiz < PaymentMethod
+    def source_required?
+      false
+    end
+  end
+end

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -15,7 +15,9 @@ Spree.config do |config|
   # Example:
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
+
 end
 
 Spree.user_class = 'Spree::User'
 Spree::Api::Config[:requires_authentication] = false
+Rails.application.config.spree.payment_methods << Spree::PaymentMethod::Payubiz

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
 
   scope module: 'api', path: 'auth', defaults: { format: :json } do
     get 'authenticated', to: 'accounts#authenticated'
+    post 'handle_payment', to: 'accounts#handle_payment'
+    post 'canceled_payment', to: 'accounts#canceled_payment'
     resources :accounts
     resources :passwords
   end


### PR DESCRIPTION
Why?

Feature:
Adding the payment method as payubiz.
Adding payubiz payment gateway for making payments.

This change addresses the need by:

Admin can be able to select the payubiz as payment method. From configurations.
User can be able to make payments using payubiz.

[delivers #158522773]