### PR TITLE
Bug Fixes 

### DIFF
--- a/app/controllers/api/accounts_controller.rb
+++ b/app/controllers/api/accounts_controller.rb
@@ -48,11 +48,13 @@ class Api::AccountsController < BaseController
 
   def handle_payment
     order_id = params[:txnid]
+    mihpayid = params[:mihpayid]
     @current_order = Spree::Order.find_by_number(order_id)
     #Assuming that we do not having partial payments(one stroke payment only)
     result = @current_order.payments.first.complete
     if result
-      url = "#{ENV['FRONT_END_URL']}checkout/order-success?orderReferance=#{order_id}"
+      @current_order.payments.first.update(response_code: mihpayid)
+      url = "#{ENV['FRONT_END_URL']}checkout/order-success?orderReferance=#{order_id}"  
       redirect_to url  
     end
   end

--- a/app/controllers/api/passwords_controller.rb
+++ b/app/controllers/api/passwords_controller.rb
@@ -3,7 +3,6 @@
 class Api::PasswordsController < BaseController
   def create
     user = Spree::User.find_by!(email: params[:spree_user][:email])
-
     token = user.send(:set_reset_password_token)
     UserMailer.reset_password_instructions(user, token).deliver
     respond_with user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,9 +1,8 @@
 class UserMailer < ActionMailer::Base
-  default from: ENV['MAIL_FROM']
   
   def reset_password_instructions(user, token)
     @user = user
     @token =token
-    mail(to: @user.email, subject: ENV['RESET_PASSWORD_SUBJECT'])
+    mail(to: @user.email, subject: 'Reset Password Instructions')
   end
 end

--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -1,11 +1,11 @@
 <p>Hello <%= @user.email %>!</p>
 
-<p align=justfy>A request to reset your password has been made.
+<p align=justfy>A request to reset your password has been made from <%= ENV['FRONT_END_URL']%>.
 If you did not make this request, simply ignore this email.
 
 If you did make this request just click the link below:</p>
 
-<p><%= link_to 'Change My Password Link', "#{ENV['ANGULAR_URL']}/auth/updatePassword?reset_password_token=#{@token}&email=#{@user.email}&id=#{@user.id}"%>
+<p><%= link_to 'Change My Password Link', "#{ENV['FRONT_END_URL']}/auth/updatePassword?reset_password_token=#{@token}&email=#{@user.email}&id=#{@user.id}"%>
 </p>
 
 <p>Your password won't change until you access the link above and create a new one.</p>


### PR DESCRIPTION
## Why?

**Bug**: 
Modified json response Ratings summery 
Added User to  review 
Added `from` email in Reset password instruction mail
Added Transaction ID for payments

## This change addresses the need by:

Ratings will be displayed from 5 to 1 in reverser order. 
Removed dependancy for spree permissions for creating review.
Now Mail settings will be picked from admin mail method setting itself.
We have transaction ID after successful payment from payubiz.

[delivers #158807262]

[Story](https://www.pivotaltracker.com/story/show/158807262)