### PR TITLE
Modified Orderlist Pagination 

### DIFF
--- a/app/views/spree/api/v1/orders/index.v1.rabl
+++ b/app/views/spree/api/v1/orders/index.v1.rabl
@@ -1,0 +1,13 @@
+object false
+if request.headers['ng-api'] == 'true'
+  extends 'spree/api/v1/orders/ng_index'
+else
+  child(@orders => :orders) do
+    extends 'spree/api/v1/orders/order'
+  end
+  node(:count) { @orders.count }
+  node(:current_page) { params[:page].try(:to_i) || 1 }
+  node(:pages) { @orders.total_pages }
+  node(:per_page) { params[:per_page].try(:to_i) || Kaminari.config.default_per_page }
+  node(:total_count) {@orders.total_count}
+end

--- a/app/views/spree/api/v1/orders/ng_index.v1.rabl
+++ b/app/views/spree/api/v1/orders/ng_index.v1.rabl
@@ -1,0 +1,10 @@
+object false
+  child(@orders => :orders) do
+    extends 'spree/api/v1/orders/order'
+  end
+
+  node(:count) { @orders.count }
+  node(:current_page) { params[:page].try(:to_i) || 1 }
+  node(:pages) { @orders.total_pages }
+  node(:per_page) { params[:per_page].try(:to_i) || Kaminari.config.default_per_page }
+  node(:total_count) {@orders.total_count}


### PR DESCRIPTION
## why?

Added `total_count` & `per_page` to order list pagination.

## This change addresses the need by:
Order list  will  have full pagination data along with newly added fields.

[delivers #158889106]

[Story](https://www.pivotaltracker.com/story/show/158889106)
