### PR TITLE
Fixes for product review

### DIFF
--- a/app/controllers/spree/reviews_controller.rb
+++ b/app/controllers/spree/reviews_controller.rb
@@ -75,14 +75,8 @@ class Spree::ReviewsController < Spree::StoreController
   end
 
   def is_already_reviewed(product_reviews)
-    product_reviews.each do |review|
-      if (review.user_id == params[:review][:user_id])
-        return true
-        break
-      else
-        return false
-      end
-    end
+    user_id = params[:review][:user_id]
+    product_reviews.find { |r| r.user_id == user_id } ? true : false
   end   
 
 end

--- a/app/controllers/spree/reviews_controller.rb
+++ b/app/controllers/spree/reviews_controller.rb
@@ -23,17 +23,25 @@ class Spree::ReviewsController < Spree::StoreController
 
   def create
     params[:review][:rating].sub!(/\s*[^0-9]*\z/, '') unless params[:review][:rating].blank?
-    @review = Spree::Review.new(review_params)
-    @review.product = @product
-    @review.user = Spree::User.find_by(id: params[:review][:user_id])
-    @review.ip_address = request.remote_ip
-    @review.locale = I18n.locale.to_s if Spree::Reviews::Config[:track_locale]
-    if @review.save
-      message = Spree.t(:review_successfully_submitted)
-      render json: { message: message }
-    else
-      message = 'Unable to submit the review'
-      render json: { error: message }
+    product_reviews = Spree::Review.where(product_id: params[:product_id])
+    if (!is_already_reviewed(product_reviews)) 
+      @review = Spree::Review.new(review_params)
+      @review.product = @product
+      @review.user = Spree::User.find_by(id: params[:review][:user_id])
+      @review.ip_address = request.remote_ip
+      @review.locale = I18n.locale.to_s if Spree::Reviews::Config[:track_locale]
+
+      if @review.save
+        message = Spree.t(:review_successfully_submitted)
+        render json: { type: :success, message: message }
+      else
+        message = 'Unable to submit the review'
+        render json: { type: :error, message: message }
+      end
+
+    else 
+      message = 'You have already reviewed this product'
+      render json: { type: :info, message: message }
     end
   end
 
@@ -63,7 +71,18 @@ class Spree::ReviewsController < Spree::StoreController
     x.each do |key, value|
       @rating_summery << { 'rating'=> key, 'count'=>value, 'percentage' => (value.to_f / ratings_array.count * 100) }
     end
-
     @rating_summery
   end
+
+  def is_already_reviewed(product_reviews)
+    product_reviews.each do |review|
+      if (review.user_id == params[:review][:user_id])
+        return true
+        break
+      else
+        return false
+      end
+    end
+  end   
+
 end


### PR DESCRIPTION
## Why?

**Bug**:  
User was allowed to submit more than one review for a particular product.

**Fix for bug**: Tracked user from reviews for a particular product and disallowed him/her from submitting review again if he had given it previously.

## This change addresses the need by:

Now a logged in user can write only one review for a product. 

[delivers #158973110]

[Story](https://www.pivotaltracker.com/story/show/158973110)
 