### PR TITLE
Failed-payment-payubiz

### DIFF
--- a/app/controllers/api/payubiz_controller.rb
+++ b/app/controllers/api/payubiz_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-
 class Api::PayubizController < BaseController
-  before_action :check_authorization, except: %i[handle_payment canceled_payment post_request_payubiz]
+  before_action :check_authorization, except: %i[handle_payment canceled_payment]
+  skip_before_action :verify_authenticity_token, only: %i[canceled_payment]
 
   def handle_payment
     transaction_id = params[:txnid]
@@ -21,9 +21,10 @@ class Api::PayubizController < BaseController
   end
 
   def canceled_payment
-    #WIP when user cancel payments
-    url = "#{ENV['FRONT_END_URL']}"
-      redirect_to url  
+    reason = params[:error_Message]
+    order_id=params[:udf1]
+    url = "#{ENV['FRONT_END_URL']}checkout/order-failed?orderReferance=#{order_id}&reason=#{reason}"  
+    redirect_to url  
   end
 
   def post_request_payubiz


### PR DESCRIPTION
## why?
**Feature**
* User redirection to failed payment(order) component when he cancel payments or any failure occurs by payubiz with failure reason.

## This change addresses the need by:
Now when user cancel payment Or any problem occurred from payubiz the user will be  redirected to failed payment page(forntend).

[delivers #159095718]
[Story](https://www.pivotaltracker.com/story/show/159095718)

