### PR TITLE
Login & reviews fixes

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -51,6 +51,7 @@ class BaseController < Spree::BaseController
 
   def set_current_user
     token = request.headers['Auth-Token']
+    return if token.blank?
     @spree_current_user = Spree::User.find_by_spree_api_key(token)
   end
 

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -3,7 +3,6 @@
 class OauthController < BaseController
   def create
     auth = Oauth.for(params[:provider]).new(params).call
-
     if auth.authorized?
       user = OauthUserCreator.new(auth.user_info, set_current_user).call
       if user
@@ -12,7 +11,7 @@ class OauthController < BaseController
                scope: user,
                serializer: LiteUserSerializer
       else
-        render json: { error: "Error linking #{params[:provider]} account" }
+        render json: { error: "Error linking #{params[:provider]} account" }, :status => 422
       end
     else
       render json: { error: "There was an error with #{params['provider']}. please try again." }, status: 422

--- a/app/controllers/spree/api/base_controller_decorator.rb
+++ b/app/controllers/spree/api/base_controller_decorator.rb
@@ -7,4 +7,9 @@ Spree::Api::BaseController.class_eval do
   def order_token
     request.headers['Order-Token'] || params[:order_token]
   end
+
+  def load_user
+    return nil if api_key.blank?
+    @current_api_user = Spree.user_class.find_by(spree_api_key: api_key.to_s)
+  end
 end

--- a/app/controllers/spree/reviews_controller.rb
+++ b/app/controllers/spree/reviews_controller.rb
@@ -64,11 +64,14 @@ class Spree::ReviewsController < Spree::StoreController
     ratings_array.each do |rate|
       counts[rate] += 1
     end
-    
+
+    for i in 1..5
+      counts.merge!(i => 0) if counts[i]==0 
+    end
 
     @rating_summery = []
-    x = counts.sort_by {|k,v| k}.reverse
-    x.each do |key, value|
+    sorted_counts = counts.sort_by {|k,v| k}.reverse
+    sorted_counts.each do |key, value|
       @rating_summery << { 'rating'=> key, 'count'=>value, 'percentage' => (value.to_f / ratings_array.count * 100) }
     end
     @rating_summery

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -20,6 +20,9 @@ class Spree::UserSessionsController < Devise::SessionsController
   def create
     # Warden authentication
     self.resource = warden.authenticate!(auth_options)
+    # Check for spree api key
+    @spree_user.generate_spree_api_key! unless @spree_user.spree_api_key?
+
     if spree_user_signed_in?
       respond_to do |format|
         format.html do

--- a/app/services/oauth_user_creator.rb
+++ b/app/services/oauth_user_creator.rb
@@ -10,21 +10,7 @@ class OauthUserCreator
 
   def call
     identity = Identity.find_or_initialize_by(uid: info.uid, provider: info.provider)
-    if @current_user
-      if identity.user == @current_user
-        # User is signed in so they are trying to link an identity with their
-        # account. But we found the identity and the user associated with it
-        # is the current user. So the identity is already associated with
-        # this user. So let's display an error message.
-        return nil
-      else
-        # The identity is not associated with the current_user so lets
-        # associate the identity
-        identity.user = @current_user
-        identity.save!
-        return identity.user
-      end
-    else
+    identity.user.generate_spree_api_key! if identity.user&.spree_api_key?
       if identity.user.present?
         # The identity we found had a user associated with it
         return identity.user
@@ -42,7 +28,6 @@ class OauthUserCreator
           return nil
         end
       end
-    end
   end
 
   private
@@ -58,7 +43,7 @@ class OauthUserCreator
         return user
       end
     else
-      user
+      return user
     end
   end
 end

--- a/app/views/spree/admin/invoice/_header.html.erb
+++ b/app/views/spree/admin/invoice/_header.html.erb
@@ -1,0 +1,11 @@
+<table>
+  <tr>
+    <td width="345"><%= image_tag Spree::HtmlInvoice::Config[:html_invoice_logo_path] || "store/invoice_logo.jpg", id: "logo",style: 'height:80%;width:auto;' %></td>
+    <td width="345">
+    <div align="right">
+      <p class="title"><%= Spree.t("#{params[:template]}.header") %></p>
+      <p class="bold"><%= Spree.t(:order_number, number: @order.number)  %></p>
+      <p class="bold"> <%=Spree.t(:order_date) %>: <%= Spree.l(@order.completed_at.to_date) if @order.completed_at %></p>
+    </div></td>
+  </tr>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,8 +2,7 @@
 en:
   spree:
     footer_right: "Website <br/> Phone"
-    footer_right2: "www.ofypets.com <br/>917-6031-568"
-
+    footer_right2: "localhost:4200 <br/> 1234567890"
     size: "Size"
     price: "Price"
     order_date: "Order date"
@@ -27,3 +26,6 @@ en:
     receipt:
       header: Receipt
       print: Receipt
+    favorite_products:
+      destroy:
+        success: "Product has been successfully removed from favorite"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,35 +1,29 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+# Add your custom information.
 en:
-  favorite_products:
-    destroy: 
-      success: "Product has been successfully removed from favorite"
+  spree:
+    footer_right: "Website <br/> Phone"
+    footer_right2: "www.ofypets.com <br/>917-6031-568"
+
+    size: "Size"
+    price: "Price"
+    order_date: "Order date"
+    ship_adjustment: "Shipping Adjustments"
+    shipment_amount: "Shipping Amount"
+    state: "State"
+    method: "Method"
+    amount: "Amount"
+    invoice:
+      header: Customer Invoice
+      thanks: Thank you for your order.
+      print: Print Invoice
+    packaging_slip:
+      header: Packaging Slip
+      print: Print Slip
+      thanks: Please check the contents immediately.
+    reminder:
+      header: Payment Reminder
+      print: Reminder
+      thanks: Our system has not registered any payment for this Invoice. We kindly request you correct this situation.
+    receipt:
+      header: Receipt
+      print: Receipt


### PR DESCRIPTION
## why?

**Bug**
* Google auth login for user with null `spree_api_key`
* User able logged in with out `api_key`

**Changes**
* Reviews summary modified for empty ratings.

## This change addresses the need by:
Every user will be having `spree_api key` whenever he/she  logged in/signUp.
Ratings response has been modified to display 5 to 1 rating even-if it is zero.  

[delivers #159332798]
[Story](https://www.pivotaltracker.com/story/show/159332798)