### PR TITLE
Sorting params to ransack

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -22,3 +22,4 @@ Spree.user_class = 'Spree::User'
 Spree::Api::Config[:requires_authentication] = false
 Rails.application.config.spree.payment_methods << Spree::PaymentMethod::Payubiz
 Rails.application.config.spree.payment_methods << Spree::PaymentMethod::Cod
+Spree::Product.whitelisted_ransackable_attributes.push('avg_rating', 'reviews_count', 'favorite_users_count', 'amount')


### PR DESCRIPTION
## Why?
**Feature**
Added sorting products by `Avg. Rating`, `Review Count`, & `favorite_user_count`.

## This change addresses the need by:
Now User can sort the search result of products by avg.rating, review_count & favorite_user_count.

For making this we need make the whitelist the columns of the product table. As spree use ransack gem so, it performs sorting according to it.

[delivers #159161098]
[Story](https://www.pivotaltracker.com/story/show/159161098)