### PR TITLE
Added extensions for Admin Insight & Analytics 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'spree_related_products', github: 'spree-contrib/spree_related_products'
 gem 'spree_reviews', github: 'spree-contrib/spree_reviews'
 gem 'spree_events_tracker', github: 'vinsol-spree-contrib/spree_events_tracker', branch: 'master'
 gem 'spree_admin_insights', git: 'https://github.com/vinsol-spree-contrib/spree-admin-insights', branch: 'master'
+gem 'spree_analytics_trackers', github: 'spree-contrib/spree_analytics_trackers'
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,8 @@ gem 'spree_mail_settings', github: 'spree-contrib/spree_mail_settings'
 gem 'spree_recently_viewed', github: 'spree-contrib/spree_recently_viewed'
 gem 'spree_related_products', github: 'spree-contrib/spree_related_products'
 gem 'spree_reviews', github: 'spree-contrib/spree_reviews'
+gem 'spree_events_tracker', github: 'vinsol-spree-contrib/spree_events_tracker', branch: 'master'
+gem 'spree_admin_insights', git: 'https://github.com/vinsol-spree-contrib/spree-admin-insights', branch: 'master'
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,17 @@ GIT
       spree_extension
 
 GIT
+  remote: https://github.com/vinsol-spree-contrib/spree-admin-insights
+  revision: f8edbe84dd595a3271c68325741a69a82b599f05
+  branch: master
+  specs:
+    spree_admin_insights (3.2.0.alpha)
+      spree_core (>= 3.1.0, < 4.0.0)
+      spree_extension
+      wicked_pdf
+      wkhtmltopdf-binary
+
+GIT
   remote: https://github.com/vinsol-spree-contrib/spree-html-invoice.git
   revision: 3f6f9eb69d8d1c5b5f48210d4b8d15e8b9c18df4
   branch: master
@@ -67,6 +78,15 @@ GIT
     spree_admin_roles_and_access (3.pre.0.pre.stable)
       spree_auth_devise
       spree_core (>= 3.2.0, < 4.0.0)
+
+GIT
+  remote: https://github.com/vinsol-spree-contrib/spree_events_tracker.git
+  revision: 57022d48ecbb8ec451970fe2e223445f5280db54
+  branch: master
+  specs:
+    spree_events_tracker (3.3.1)
+      spree_core (>= 3.2.0, < 4.0)
+      spree_extension (~> 0.0.5)
 
 GIT
   remote: https://github.com/vinsol-spree-contrib/spree_favorite_products.git
@@ -574,6 +594,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    wicked_pdf (1.1.0)
+    wkhtmltopdf-binary (0.12.4)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -607,9 +629,11 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   spree (~> 3.6.0)
+  spree_admin_insights!
   spree_admin_roles_and_access!
   spree_auth_devise!
   spree_editor!
+  spree_events_tracker!
   spree_favorite_products!
   spree_gateway (~> 3.3)
   spree_html_invoice!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/spree-contrib/spree_analytics_trackers.git
+  revision: c891a9f51cb13d9316bb1197d9c2f8034aab6cf1
+  specs:
+    spree_analytics_trackers (1.0.0.rc2)
+      spree_backend (>= 3.1.0, < 4.0)
+      spree_core (>= 3.1.0, < 4.0)
+      spree_extension
+
+GIT
   remote: https://github.com/spree-contrib/spree_editor.git
   revision: c3d147ac19bae1080e442f3002becafe71f0cdac
   specs:
@@ -631,6 +640,7 @@ DEPENDENCIES
   spree (~> 3.6.0)
   spree_admin_insights!
   spree_admin_roles_and_access!
+  spree_analytics_trackers!
   spree_auth_devise!
   spree_editor!
   spree_events_tracker!

--- a/config/initializers/spree_admin_insights.rb
+++ b/config/initializers/spree_admin_insights.rb
@@ -1,0 +1,22 @@
+reports = {
+  finance_analysis:           [
+    :payment_method_transactions, :payment_method_transactions_conversion_rate,
+    :shipping_cost, :sales_tax, :sales_performance
+  ],
+  product_analysis:           [
+    :best_selling_products, :cart_additions, :cart_removals, :cart_updations,
+    :product_views, :product_views_to_cart_additions,
+    :product_views_to_purchases, :unique_purchases,
+    :returned_products
+  ],
+  promotion_analysis:         [:promotional_cost],
+  trending_search_analysis:   [:trending_search],
+  user_analysis:              [:user_pool, :users_not_converted, :users_who_recently_purchased],
+}
+
+SpreeAdminInsights::Config.configure do |config|
+  reports.keys.each do |report_category|
+    config.register_report_category(report_category)
+    reports[report_category].each { |report| config.register_report(report_category, report) }
+  end
+end

--- a/db/migrate/20180801061208_create_spree_cart_events.spree_events_tracker.rb
+++ b/db/migrate/20180801061208_create_spree_cart_events.spree_events_tracker.rb
@@ -1,0 +1,16 @@
+# This migration comes from spree_events_tracker (originally 20160313145434)
+class CreateSpreeCartEvents < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_cart_events do |t|
+      t.belongs_to :actor, polymorphic: true, index: true
+      t.belongs_to :target, polymorphic: true, index: true
+      t.string :activity
+      t.string :referrer
+      t.integer :quantity
+      t.decimal :total, precision: 16, scale: 4
+      t.string :session_id
+      t.belongs_to :variant, index: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180801061209_create_spree_page_events.spree_events_tracker.rb
+++ b/db/migrate/20180801061209_create_spree_page_events.spree_events_tracker.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree_events_tracker (originally 20160314080710)
+class CreateSpreePageEvents < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_page_events do |t|
+      t.belongs_to :actor, polymorphic: true, index: true
+      t.belongs_to :target, polymorphic: true, index: true
+      t.string :activity
+      t.string :referrer
+      t.string :search_keywords
+      t.string :session_id
+      t.string :query_string
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180801061210_create_spree_checkout_events.spree_events_tracker.rb
+++ b/db/migrate/20180801061210_create_spree_checkout_events.spree_events_tracker.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree_events_tracker (originally 20160314080822)
+class CreateSpreeCheckoutEvents < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_checkout_events do |t|
+      t.belongs_to :actor, polymorphic: true, index: true
+      t.belongs_to :target, polymorphic: true, index: true
+      t.string :activity
+      t.string :referrer
+      t.string :previous_state
+      t.string :next_state
+      t.string :session_id
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180801061211_change_query_string_to_text.spree_events_tracker.rb
+++ b/db/migrate/20180801061211_change_query_string_to_text.spree_events_tracker.rb
@@ -1,0 +1,12 @@
+# This migration comes from spree_events_tracker (originally 20160710173455)
+class ChangeQueryStringToText < SpreeExtension::Migration[4.2]
+  def up
+    change_column :spree_page_events, :query_string, :text
+  end
+
+  def down
+    # This might cause trouble if you have strings longer
+    # than 255 characters.
+    change_column :spree_page_events, :query_string, :string
+  end
+end

--- a/db/migrate/20180801061212_change_referrer_to_text_from_string.spree_events_tracker.rb
+++ b/db/migrate/20180801061212_change_referrer_to_text_from_string.spree_events_tracker.rb
@@ -1,0 +1,17 @@
+# This migration comes from spree_events_tracker (originally 20160710182337)
+class ChangeReferrerToTextFromString < SpreeExtension::Migration[4.2]
+  def up
+    change_column :spree_cart_events, :referrer, :text
+    change_column :spree_page_events, :referrer, :text
+    change_column :spree_checkout_events, :referrer, :text
+  end
+
+  def down
+    # This might cause trouble if you have strings longer
+    # than 255 characters.
+    change_column :spree_cart_events, :referrer, :string
+    change_column :spree_page_events, :referrer, :string
+    change_column :spree_checkout_events, :referrer, :string
+  end
+
+end

--- a/db/migrate/20180801072719_create_spree_trackers.spree_analytics_trackers.rb
+++ b/db/migrate/20180801072719_create_spree_trackers.spree_analytics_trackers.rb
@@ -1,0 +1,21 @@
+# This migration comes from spree_analytics_trackers (originally 20171013160337)
+class CreateSpreeTrackers < SpreeExtension::Migration[4.2]
+  def change
+    if table_exists?(:spree_trackers)
+      add_index :spree_trackers, :active unless index_exists?(:spree_trackers, :active)
+      remove_column :spree_trackers, :environment if column_exists?(:spree_trackers, :environment)
+      unless column_exists?(:spree_trackers, :engine)
+        add_column :spree_trackers, :kind, :integer, default: 0, null: false, index: true unless column_exists?(:spree_trackers, :kind)
+        rename_column :spree_trackers, :kind, :engine if column_exists?(:spree_trackers, :kind)
+      end
+    else
+      create_table :spree_trackers do |t|
+        t.string 'analytics_id'
+        t.boolean 'active', default: true, index: true
+        t.datetime 'created_at', null: false
+        t.datetime 'updated_at', null: false
+        t.integer 'engine', default: 0, null: false, index: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_19_070622) do
+ActiveRecord::Schema.define(version: 2018_08_01_061212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,6 +151,40 @@ ActiveRecord::Schema.define(version: 2018_07_19_070622) do
     t.index ["calculable_id", "calculable_type"], name: "index_spree_calculators_on_calculable_id_and_calculable_type"
     t.index ["deleted_at"], name: "index_spree_calculators_on_deleted_at"
     t.index ["id", "type"], name: "index_spree_calculators_on_id_and_type"
+  end
+
+  create_table "spree_cart_events", id: :serial, force: :cascade do |t|
+    t.string "actor_type"
+    t.integer "actor_id"
+    t.string "target_type"
+    t.integer "target_id"
+    t.string "activity"
+    t.text "referrer"
+    t.integer "quantity"
+    t.decimal "total", precision: 16, scale: 4
+    t.string "session_id"
+    t.integer "variant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_type", "actor_id"], name: "index_spree_cart_events_on_actor_type_and_actor_id"
+    t.index ["target_type", "target_id"], name: "index_spree_cart_events_on_target_type_and_target_id"
+    t.index ["variant_id"], name: "index_spree_cart_events_on_variant_id"
+  end
+
+  create_table "spree_checkout_events", id: :serial, force: :cascade do |t|
+    t.string "actor_type"
+    t.integer "actor_id"
+    t.string "target_type"
+    t.integer "target_id"
+    t.string "activity"
+    t.text "referrer"
+    t.string "previous_state"
+    t.string "next_state"
+    t.string "session_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_type", "actor_id"], name: "index_spree_checkout_events_on_actor_type_and_actor_id"
+    t.index ["target_type", "target_id"], name: "index_spree_checkout_events_on_target_type_and_target_id"
   end
 
   create_table "spree_countries", force: :cascade do |t|
@@ -399,6 +433,22 @@ ActiveRecord::Schema.define(version: 2018_07_19_070622) do
     t.index ["ship_address_id"], name: "index_spree_orders_on_ship_address_id"
     t.index ["store_id"], name: "index_spree_orders_on_store_id"
     t.index ["user_id", "created_by_id"], name: "index_spree_orders_on_user_id_and_created_by_id"
+  end
+
+  create_table "spree_page_events", id: :serial, force: :cascade do |t|
+    t.string "actor_type"
+    t.integer "actor_id"
+    t.string "target_type"
+    t.integer "target_id"
+    t.string "activity"
+    t.text "referrer"
+    t.string "search_keywords"
+    t.string "session_id"
+    t.text "query_string"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_type", "actor_id"], name: "index_spree_page_events_on_actor_type_and_actor_id"
+    t.index ["target_type", "target_id"], name: "index_spree_page_events_on_target_type_and_target_id"
   end
 
   create_table "spree_payment_capture_events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_01_061212) do
+ActiveRecord::Schema.define(version: 2018_08_01_072719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/vendor/assets/javascripts/spree/backend/all.js
+++ b/vendor/assets/javascripts/spree/backend/all.js
@@ -15,3 +15,4 @@
 //= require spree/backend/spree_reviews
 //= require spree/backend/spree_events_tracker
 //= require spree/backend/spree_admin_insights
+//= require spree/backend/spree_analytics_trackers

--- a/vendor/assets/javascripts/spree/backend/all.js
+++ b/vendor/assets/javascripts/spree/backend/all.js
@@ -13,3 +13,5 @@
 //= require admin/spree_favorite_products
 //= require spree/backend/spree_admin_roles_and_access
 //= require spree/backend/spree_reviews
+//= require spree/backend/spree_events_tracker
+//= require spree/backend/spree_admin_insights

--- a/vendor/assets/javascripts/spree/frontend/all.js
+++ b/vendor/assets/javascripts/spree/frontend/all.js
@@ -20,3 +20,4 @@
 //= require spree/frontend/spree_reviews
 //= require spree/frontend/spree_events_tracker
 //= require spree/frontend/spree_admin_insights
+//= require spree/frontend/spree_analytics_trackers

--- a/vendor/assets/javascripts/spree/frontend/all.js
+++ b/vendor/assets/javascripts/spree/frontend/all.js
@@ -18,3 +18,5 @@
 //= require spree/frontend/spree_admin_roles_and_access
 //= require spree/frontend/spree_recently_viewed
 //= require spree/frontend/spree_reviews
+//= require spree/frontend/spree_events_tracker
+//= require spree/frontend/spree_admin_insights

--- a/vendor/assets/stylesheets/spree/backend/all.css
+++ b/vendor/assets/stylesheets/spree/backend/all.css
@@ -12,4 +12,5 @@
  *= require spree/backend/spree_editor
  *= require spree/backend/spree_events_tracker
  *= require spree/backend/spree_admin_insights
+ *= require spree/backend/spree_analytics_trackers
 */

--- a/vendor/assets/stylesheets/spree/backend/all.css
+++ b/vendor/assets/stylesheets/spree/backend/all.css
@@ -10,4 +10,6 @@
  *= require admin/spree_favorite_products
  *= require spree/backend/spree_admin_roles_and_access
  *= require spree/backend/spree_editor
+ *= require spree/backend/spree_events_tracker
+ *= require spree/backend/spree_admin_insights
 */

--- a/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/vendor/assets/stylesheets/spree/frontend/all.css
@@ -12,4 +12,5 @@
  *= require spree/frontend/spree_reviews
  *= require spree/frontend/spree_events_tracker
  *= require spree/frontend/spree_admin_insights
+ *= require spree/frontend/spree_analytics_trackers
 */

--- a/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/vendor/assets/stylesheets/spree/frontend/all.css
@@ -10,4 +10,6 @@
  *= require store/spree_favorite_products
  *= require spree/frontend/spree_admin_roles_and_access
  *= require spree/frontend/spree_reviews
+ *= require spree/frontend/spree_events_tracker
+ *= require spree/frontend/spree_admin_insights
 */


### PR DESCRIPTION
## Why?

**Added extensions**

* [vinsol-spree-contrib/spree_events_tracker](https://github.com/vinsol-spree-contrib/spree_events_tracker)
* [vinsol-spree-contrib/spree-admin-insights](https://github.com/vinsol-spree-contrib/spree-admin-insights)
* [spree-contrib/spree_analytics_trackers](https://github.com/spree-contrib/spree_analytics_trackers)

## This change addresses the need by:

Now spree admin will have `Insight` & `Analytics` options in admin panel. Which will have added functionality for admin.


[delivers #159456776]
[Story](https://www.pivotaltracker.com/story/show/159456776)
