### PR TITLE
Added api for user address

### DIFF
--- a/app/controllers/api/addresses_controller.rb
+++ b/app/controllers/api/addresses_controller.rb
@@ -21,4 +21,27 @@ class Api::AddressesController < BaseController
     render json: {available: true } if result !=nil
     render json: {available: false } if result == nil
   end
+
+  def update_address 
+    if params[:user][:email].blank?
+      render json: { errors: 'Address can not be update' }, status: 422
+    else
+      user= Spree::User.find_by!(email: params[:user][:email])
+      hashParams = (params[:user][:ship_address].to_unsafe_h)
+      updated = user.ship_address.update(hashParams)      
+      render json: {status: "Address updated Successfully!"} if updated
+    end 
+  end
+
+  def create_address 
+    if params[:user][:email].blank?
+      render json: { errors: 'Address can not be added' }, status: 422
+    else
+      user= Spree::User.find_by!(email: params[:user][:email])
+      hashParams = (params[:user][:ship_address].to_unsafe_h)
+      updated = user.create_ship_address(hashParams)
+      user.save      
+      render json: {status: "Address added Successfully!"} if updated
+    end 
+  end
 end

--- a/app/controllers/api/passwords_controller.rb
+++ b/app/controllers/api/passwords_controller.rb
@@ -13,9 +13,11 @@ class Api::PasswordsController < BaseController
       user = Spree::User.new
       user.errors[:password] = 'Cannot be blank'
     else
-      user = Spree::User.reset_password_by_token(params[:spree_user])
+      user= Spree::User.find_by!(email: params[:spree_user][:email])
+      params.require(:spree_user).permit(:password)
+      updated = user.update_attributes(:password => params[:spree_user][:password])
       sign_in :spree_user, user if user.errors.empty?
+      render json: {status: "Password changed Successfully!"} if updated
     end
-    respond_with user
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,11 +35,14 @@ Rails.application.routes.draw do
   scope module: 'api', path: 'auth', defaults: { format: :json } do
     get 'authenticated', to: 'accounts#authenticated'
     resources :accounts
+    put 'change_password', to: 'passwords#update'
     resources :passwords
   end
 
   scope module: 'api', path: 'address', defaults: {format: :json} do
     post 'shipment_availability', to: 'addresses#shipment_availability'
+    post  'update_address', to: 'addresses#update_address'
+    post 'create_address', to: 'addresses#create_address'
     resources :addresses
   end
 


### PR DESCRIPTION
## Why?
**Fetures**
* API for create & update user address.
* Changed api for user password change.

## This change addresses the need by:  
Now We have API for changing the password for user profile and for creating and editing user address.(shipping).

**API route for Frontend**
* For address edit
`<host>/address/update_address` (Post) 
params
```
user:  {
             email: <email>,
             ship_address: <ship_address>
       }
```
* For address create 
`<host>/address/create_address` (Post) 
params
```
user:  {
             email: <email>,
             ship_address: <ship_address>
       }
```
[delivers #159519704]
[story](https://www.pivotaltracker.com/story/show/159519704)
